### PR TITLE
fix: ExcludeOrganizationalUnit validation

### DIFF
--- a/src/parser/validator.ts
+++ b/src/parser/validator.ts
@@ -119,7 +119,7 @@ export class Validator {
             Validator.validateReferenceToOU(binding.OrganizationalUnit, id);
         }
         if (binding.ExcludeOrganizationalUnit !== undefined) {
-            Validator.validateReferenceToOU(binding.OrganizationalUnit, id);
+            Validator.validateReferenceToOU(binding.ExcludeOrganizationalUnit, id);
         }
         if (binding.IncludeMasterAccount !== undefined) {
             if (typeof binding.IncludeMasterAccount !== 'boolean') {


### PR DESCRIPTION
When `binding.ExcludeOrganizationalUnit` exists, `binding.OrganizationalUnit` was incorrectly being passed to `Validator.validateReferenceToOU()` in its place.

This typo can cause either:
1. an invalid `ExcludeOrganizationalUnit` to slip by, or
2. an unintended error when a valid `ExcludeOrganizationalUnit` binding exists alone without a valid `OrganizationalUnit` binding.